### PR TITLE
Improve `git clone` & `checkout` process in Dockerfiles

### DIFF
--- a/baresip/Dockerfile
+++ b/baresip/Dockerfile
@@ -3,7 +3,7 @@ FROM ${IMAGE}
 ARG VERSION
 RUN install_packages libopus-dev libasound2-dev libmosquitto-dev libspandsp-dev libpulse-dev
 WORKDIR /root/
-RUN git clone -b ${VERSION} --single-branch https://github.com/baresip/baresip.git && \
+RUN git clone -b ${VERSION} --depth=1 https://github.com/baresip/baresip.git && \
     cd baresip && \
     cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang-11 \
         -DCMAKE_CXX_COMPILER=clang++-11 -DCMAKE_INSTALL_PREFIX=/usr && \

--- a/libre/Dockerfile
+++ b/libre/Dockerfile
@@ -2,8 +2,8 @@ FROM bitnami/minideb:bullseye
 ARG VERSION
 WORKDIR /root/
 RUN install_packages clang-11 make cmake pkg-config git libssl-dev wget ca-certificates libz-dev && \
-    git clone https://github.com/baresip/re.git && \
-    cd re && git checkout ${VERSION} && \
+    git clone -b ${VERSION} --depth=1 https://github.com/baresip/re.git && \
+    cd re && \
     cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang-11 && \
     cmake --build build -j && \
     cmake --install build --prefix dist && cp -a dist/* /usr/

--- a/restund/Dockerfile
+++ b/restund/Dockerfile
@@ -3,8 +3,8 @@ FROM ${IMAGE}
 ARG VERSION
 ARG RELEASE
 WORKDIR /root/
-RUN git clone https://github.com/baresip/restund.git && \
-    cd restund && git checkout ${VERSION} && \
+RUN git clone -b ${VERSION} --depth=1 https://github.com/baresip/restund.git && \
+    cd restund && \
     make CC=clang-11 info install RELEASE=${RELEASE} DESTDIR=dist -j
 RUN mkdir /root/dist && \
     cp -a /root/re/dist/usr /root/dist/ && \


### PR DESCRIPTION
Just let git only clone the branch it needs with the minimum repository history.

This will speed up the build process a little bit, and make the image a little bit smaller.